### PR TITLE
设备管理小程序端v1.3_Update

### DIFF
--- a/miniprogram/component/eqpDocList/eqpDocList.js
+++ b/miniprogram/component/eqpDocList/eqpDocList.js
@@ -1,6 +1,7 @@
 // component/eqpDocList/eqpDocList.js
 import Notify from '../../component/vant/notify/notify';
 
+var util = require("../../utils/eamCommonUtils.js");
 var app = getApp();
 var searchBarHeight;
 var topTabHeight;
@@ -33,8 +34,8 @@ Component({
     orderState: null,
     winHeight: 900,
     currentTab: 0,     //当前显示tab的下标
-    navTab: ['全部', '处理中', '已完成'],
-    navTabPro: [{value:'全部',showScrollBar:true}, {value:'处理中',showScrollBar:false}, {value:'已完成',showScrollBar:false}],
+    navTab: ['处理中', '全部', '已完成'],
+    navTabPro: [{value:'处理中',showScrollBar:true}, {value:'全部',showScrollBar:false}, {value:'已完成',showScrollBar:false}],
     loading: true,
     refreshTrigger: false,
     show:{
@@ -502,7 +503,10 @@ Component({
       // }
       //restUrl += '/f;deptno=' + '13000' + '/s';
 
-      if(this.data.deptFilterChecked == true){
+      if(app.globalData.defaultDeptId.indexOf("1P000") >= 0){
+        restUrl += '/f';
+      }
+      else if(this.data.deptFilterChecked == true){
         if(app.globalData.defaultDeptId.indexOf("1W3") >= 0){
           restUrl += '/f';
         }
@@ -517,14 +521,14 @@ Component({
         restUrl += '/f;repairuser=' + res;
       }
 
-      if(this.data.currentTab == '1'){
-        restUrl += ';ALL=ALL';
-      }
-      else if(this.data.currentTab == '2'){
+      if(this.data.currentTab == '2'){
         restUrl += ';rstatus=95';
       }
       else if(this.data.statusFilterObj.statusCode != null &&  this.data.statusFilterObj.statusCode != ''){
         restUrl += ';rstatus=' + this.data.statusFilterObj.statusCode;
+      }
+      else if(this.data.currentTab == '0'){
+        restUrl += ';ALL=ALL';
       }
 
       if(this.data.dateFilterChecked == true){
@@ -596,7 +600,7 @@ Component({
             newItem.orderdtt = repairDocListDta[i].assetno == null ? '其他设备' : repairDocListDta[i].assetno.assetDesc;
             newItem.couponname = '品名';
             newItem.productcount = repairDocListDta[i].assetno == null ? '1' : repairDocListDta[i].assetno.qty;
-            newItem.ordernum = _this.utcInit(repairDocListDta[i].hitchtime);
+            newItem.ordernum = util.utcInit(repairDocListDta[i].hitchtime);
             newItem.payamount = repairDocListDta[i].repairusername;
             _this.data.repairDocListArray[currentTemp].push(newItem);
           }
@@ -631,6 +635,7 @@ Component({
         //console.log(rect);
         //console.log("endHeight" + that.properties.endHeight);
         let heightTemp = that.properties.endHeight-rect.bottom;
+        heightTemp = parseInt(heightTemp);
         that.setData({
           winHeight:heightTemp
         });
@@ -668,9 +673,9 @@ Component({
     },
     getDocStatusCodeByTabId: function(currentTab){
       switch(currentTab) {
-        case "0":
-            return '';
         case "1":
+            return '';
+        case "0":
             return 'ALL';
         case "2":
             return '95';
@@ -724,10 +729,16 @@ Component({
     ready: function(){
       //视图层布局完成
       //this.getSearchBarRect();
+      var statusFilterValueTemp = "请选择";
+      var statusFilterObjTemp = {statusDesc:'请选择',statusCode:null};
       this.getStartViewHeight();
+      if(app.globalData.defaultDeptId.indexOf("1P000") >= 0){
+        statusFilterValueTemp = "经理审核";
+        statusFilterObjTemp = {statusDesc:'经理审核',statusCode:'70'};
+      }
       this.setData({
-        statusFilterValue: "请选择",
-        statusFilterObj: {statusDesc:'请选择',statusCode:null},
+        statusFilterValue: statusFilterValueTemp,
+        statusFilterObj: statusFilterObjTemp,
         deptFilterChecked: false,
         dateFilterChecked: false,
         startDateFilter: null,

--- a/miniprogram/component/eqpRepairBacklogList/eqpRepairBacklogList.js
+++ b/miniprogram/component/eqpRepairBacklogList/eqpRepairBacklogList.js
@@ -1,4 +1,5 @@
 var app = getApp();
+var util = require("../../utils/eamCommonUtils.js");
 Component({
   /**
    * 组件的属性列表
@@ -30,13 +31,22 @@ Component({
       var _this = this;
       var repairBacklogList = null;
       var restUrl = app.globalData.restAdd + '/Hanbell-JRS/api/shbeam/equipmentrepair/getRepairBacklogList';
-      if(app.globalData.defaultDeptId.indexOf("1W3") >= 0){
+
+      if(app.globalData.defaultDeptId.indexOf("1P000") >= 0){
+        restUrl += '/f;rstatus=70';
+      }
+      else if(app.globalData.defaultDeptId.indexOf("1W3") >= 0){
         restUrl += '/f;serviceuser=' + res;
       }
       else{
         restUrl += '/f;repairuser=' + res;
       }
+
       restUrl += ';ALL=ALL';
+
+      if(app.globalData.defaultDeptId.indexOf("1W300") >= 0){
+        restUrl += ';ManagerCheck=ManagerCheck';
+      }
 
       restUrl += '/s/' + 0 + '/' + 20;
       //console.log(restUrl);
@@ -79,7 +89,7 @@ Component({
             let newItem = {pId:'',userNo:'',creDate:'',contenct:'',isRead:''};
             newItem.pId = repairBacklogList[i].formid;
             newItem.userNo = repairBacklogList[i].repairusername;
-            newItem.creDate = _this.utcInit(repairBacklogList[i].hitchtime);
+            newItem.creDate = util.utcInit(repairBacklogList[i].hitchtime);
             newItem.contenct = _this.getDocStatus(repairBacklogList[i].rstatus);
             newItem.isRead = repairBacklogList[i].status;
             _this.data.repairBacklogList.push(newItem);

--- a/miniprogram/eam/pages/eqpManagement/eqpRepairApprove.js
+++ b/miniprogram/eam/pages/eqpManagement/eqpRepairApprove.js
@@ -133,7 +133,7 @@ Page({
     measure:'',
     rStatus:'',
     reRepairFlag: null,
-
+    needArchiveFlag: null,
     auditTabActive: 0,
 
     formatter(type, value) {
@@ -1355,6 +1355,7 @@ upload: function(e) {
             abraseHitchObj: {abraseHitchDesc:abraseHitchTemp},
             hitchTypeObj: {hitchTypeName: eqpRepairInfo.hitchtype == null ? '' : eqpRepairInfo.hitchtype},
             reRepairFlag: eqpRepairInfo.remark == null ? 'false' : (eqpRepairInfo.remark == "true"),
+            needArchiveFlag: eqpRepairInfo.repairarchive == null ? 'false' :(eqpRepairInfo.repairarchive == "Y"),
             hitchDesc:eqpRepairInfo.hitchdesc == null ? '' : eqpRepairInfo.hitchdesc,
             hitchAlarm:eqpRepairInfo.hitchalarm == null ? '' : eqpRepairInfo.hitchalarm,
             hitchReason:eqpRepairInfo.hitchreason == null ? '' : eqpRepairInfo.hitchreason,
@@ -1397,7 +1398,7 @@ upload: function(e) {
     var eqpInfoObj = JSON.stringify(that.data.eqpRepairInfoList[0]);
     //console.log(eqpInfoObj);
     wx.navigateTo({
-      url: '../eqpManagement/eqpRepairDoApproveCheck?eqpInfo=' + eqpInfoObj + '&docFormid=' + that.data.docFormid + '&docId=' + that.data.docId + '&rStatus=' + that.data.rStatus + '&reRepairFlag=' + that.data.reRepairFlag + '&downTime=' + that.data.downTime
+      url: '../eqpManagement/eqpRepairDoApproveCheck?eqpInfo=' + eqpInfoObj + '&docFormid=' + that.data.docFormid + '&docId=' + that.data.docId + '&rStatus=' + that.data.rStatus + '&reRepairFlag=' + that.data.reRepairFlag + '&needArchiveFlag=' + that.data.needArchiveFlag + '&downTime=' + that.data.downTime + '&repairCost=' + that.data.repairCost
     });
   },
 

--- a/miniprogram/eam/pages/eqpManagement/eqpRepairAuditCheck.js
+++ b/miniprogram/eam/pages/eqpManagement/eqpRepairAuditCheck.js
@@ -4,6 +4,7 @@ const years = []
 const months = []
 const days = []
 import Dialog from '../../../component/vant/dialog/dialog';
+var util = require("../../../utils/eamCommonUtils.js");
 for (let i = 1990; i <= date.getFullYear(); i++) {
   years.push(i)
 }
@@ -1909,7 +1910,7 @@ upload: function(e) {
             newItem.pId = repairHisListInfo[i].pid;
             newItem.userNo = repairHisListInfo[i].userno;
             newItem.userName = repairHisListInfo[i].username;
-            newItem.creDate = _this.utcInit(repairHisListInfo[i].credate);
+            newItem.creDate = util.utcInit(repairHisListInfo[i].credate);
             newItem.contenct = repairHisListInfo[i].contenct;
             newItem.note = repairHisListInfo[i].note;
             _this.data.repairHisList.push(newItem);

--- a/miniprogram/eam/pages/eqpManagement/eqpRepairAuditCheck.wxml
+++ b/miniprogram/eam/pages/eqpManagement/eqpRepairAuditCheck.wxml
@@ -303,7 +303,7 @@
           <view slot="button" class="btnSlot_Minite">(分钟)</view>
         </van-field>
 
-				<van-cell center title="二次维修">
+				<van-cell center title="重复维修">
 					<van-switch class="cellSwitchPro" size="24px" checked="{{ reRepairFlag }}" bind:change="on2ndRepairChange" />
 				</van-cell>
 			</view>

--- a/miniprogram/eam/pages/eqpManagement/eqpRepairDetailCheck.js
+++ b/miniprogram/eam/pages/eqpManagement/eqpRepairDetailCheck.js
@@ -4,6 +4,7 @@ const years = []
 const months = []
 const days = []
 import Dialog from '../../../component/vant/dialog/dialog';
+var util = require("../../../utils/eamCommonUtils.js");
 for (let i = 1990; i <= date.getFullYear(); i++) {
   years.push(i)
 }
@@ -1521,20 +1522,20 @@ upload: function(e) {
 
   getTotalPrice:function(){
     console.log("total price start");
-    // var spareListTemp = this.data.spareUsedList;
-    // var totalPrice = 0;
-    // var spareCostTemp = 0;
-    // var repairCostTemp = isNaN(parseFloat(this.data.repairCost)) ? 0 : parseFloat(this.data.repairCost);
-    // var laborCostTemp = isNaN(parseFloat(this.data.laborCost)) ? 0 : parseFloat(this.data.laborCost);
-    // for(var i = 0 ; i < spareListTemp.length ; i++){
-    //   totalPrice = totalPrice + spareListTemp[i].uPrice * spareListTemp[i].qty;
-    // }
-    // spareCostTemp = totalPrice;
-    // totalPrice = (totalPrice + repairCostTemp + laborCostTemp).toFixed(2) * 100;
-    // this.setData({
-    //   totalPrice : totalPrice,
-    //   spareCost : spareCostTemp,
-    // });
+    var spareListTemp = this.data.spareUsedList;
+    var totalPrice = 0;
+    var spareCostTemp = 0;
+    var repairCostTemp = isNaN(parseFloat(this.data.repairCost)) ? 0 : parseFloat(this.data.repairCost);
+    var laborCostTemp = isNaN(parseFloat(this.data.laborCost)) ? 0 : parseFloat(this.data.laborCost);
+    for(var i = 0 ; i < spareListTemp.length ; i++){
+      totalPrice = totalPrice + spareListTemp[i].uPrice * spareListTemp[i].qty;
+    }
+    spareCostTemp = totalPrice;
+    totalPrice = (totalPrice + repairCostTemp + laborCostTemp).toFixed(2) * 100;
+    this.setData({
+      totalPrice : totalPrice,
+      spareCost : spareCostTemp,
+    });
   },
 
   /**
@@ -1928,7 +1929,7 @@ upload: function(e) {
             newItem.pId = repairHisListInfo[i].pid;
             newItem.userNo = repairHisListInfo[i].userno;
             newItem.userName = repairHisListInfo[i].username;
-            newItem.creDate = _this.utcInit(repairHisListInfo[i].credate);
+            newItem.creDate = util.utcInit(repairHisListInfo[i].credate);
             newItem.contenct = repairHisListInfo[i].contenct;
             newItem.note = repairHisListInfo[i].note;
             _this.data.repairHisList.push(newItem);

--- a/miniprogram/eam/pages/eqpManagement/eqpRepairDetailCheck.wxml
+++ b/miniprogram/eam/pages/eqpManagement/eqpRepairDetailCheck.wxml
@@ -303,7 +303,7 @@
           <view slot="button" class="btnSlot_Minite">(分钟)</view>
         </van-field>
 
-				<van-cell center title="二次维修">
+				<van-cell center title="重复维修">
 					<van-switch class="cellSwitchPro" size="24px" checked="{{ reRepairFlag }}" />
 				</van-cell>
 			</view>

--- a/miniprogram/eam/pages/eqpManagement/eqpRepairDoApproveCheck.wxml
+++ b/miniprogram/eam/pages/eqpManagement/eqpRepairDoApproveCheck.wxml
@@ -188,8 +188,16 @@
 				<van-field label="审批人" value="{{ approveUserName }}" data-name="approveUserName" use-button-slot readonly >
         </van-field>
 
-				<van-cell center title="二次维修">
-					<van-switch class="cellSwitchPro" size="24px" checked="{{ reRepairFlag }}" bind:change="on2ndRepairChange" />
+				<van-field wx:if="{{rStatus!='70'}}" label="其他费用" value="{{ repairCost }}" data-name="repairCost" bind:change="bindData" use-button-slot>
+        	<view slot="button" class="btnSlot_Yuan">¥</view>
+        </van-field>
+
+				<van-cell center title="重复维修">
+					<van-switch class="cellSwitchPro" size="24px" checked="{{ reRepairFlag }}" bind:change="on2ndRepairChange" disabled="{{rStatus=='70'}}" />
+				</van-cell>
+
+				<van-cell center title="是否归档">
+					<van-switch class="cellSwitchPro" size="24px" checked="{{ needArchiveFlag }}" bind:change="onNeedArchiveChange" disabled="{{rStatus=='70'}}" />
 				</van-cell>
 
         <!-- <van-field label="审批结果" value="{{ auditContenctObj.contenctDesc }}" data-name="contenctDesc" bind:change="bindData" right-icon="arrow-down" bindtap='onAuditContenctCellTap' readonly /> -->

--- a/miniprogram/eam/pages/eqpManagement/eqpRepairDocDetail.wxml
+++ b/miniprogram/eam/pages/eqpManagement/eqpRepairDocDetail.wxml
@@ -23,7 +23,10 @@
     label="报修人"
     value="{{ repairUserName }}"
     data-name="repairUserName"
+    data-mobile="repairUserMobile"
     bind:change="bindData"
+    right-icon="phone"
+    bind:click-icon="mobileIconClick"
     readonly
   />
 
@@ -112,8 +115,10 @@
     label="维修人"
     value="{{serviceusername}}"
     data-name="serviceusername"
+    data-mobile="serviceuserMobile"
     bind:change="bindData"
     right-icon="phone"
+    bind:click-icon="mobileIconClick"
     readonly
   />
 
@@ -206,22 +211,22 @@
 </view>
 
 <van-cell-group>
-  <van-cell border="{{ true }}" style="width:100%;position:fixed;bottom:0px;border-top: 2rpx solid #eee;z-index: 999;">
-  <view>
-    <van-button round wx:if="{{showBtn.deleteBtn}}" color="#DCDCDC" size="small" custom-style="color:#696969;" bind:click="onDeleteBtnClick" >作废</van-button>
-    <van-button round wx:if="{{showBtn.detailCheckBtn}}" type="info" size="small" custom-style="margin-left:10px;" bind:click="onDetailBtnClick">维修详情</van-button>
-    <van-button round wx:if="{{showBtn.arrivalCheckBtn}}" disabled="{{disableBtn.arrivalCheckBtn}}" type="info" size="small" custom-style="margin-left:10px;" bind:click="onCheckBtnClick">维修员到达</van-button>
-    <van-button round wx:if="{{showBtn.finishCheckBtn}}" disabled="{{disableBtn.finishCheckBtn}}"  type="info" size="small" custom-style="margin-left:10px;" bind:click="onFinishBtnClick">确认维修完成</van-button>
-    <van-button round wx:if="{{showBtn.changeServiceUserBtn}}" type="info" size="small" custom-style="margin-left:10px;" bind:click="onChangeServiceUserBtnClick">转派维修人</van-button>
-    <van-button round wx:if="{{showBtn.startAuditBtn}}" type="info" size="small" custom-style="margin-left:10px;" bind:click="onAuditBtnClick">发起维修验收</van-button>
-    <van-button round wx:if="{{showBtn.saveRepairInfoBtn}}" disabled="{{disableBtn.saveRepairInfoBtn}}"  type="info" size="small" custom-style="margin-left:10px;" bind:click="onAuditBtnClick">记录维修过程</van-button>
-    <van-button round wx:if="{{showBtn.stopRepairBtn}}" disabled="{{disableBtn.stopRepairBtn}}" type="info" size="small" custom-style="margin-left:10px;" bind:click="onStopBtnClick">暂停维修</van-button>
-    <van-button round wx:if="{{showBtn.startRepairBtn}}" disabled="{{disableBtn.startRepairBtn}}" type="info" size="small" custom-style="margin-left:10px;" bind:click="onStartBtnClick">开始维修</van-button>
-    <van-button round wx:if="{{showBtn.responseDutyBtn}}" type="info" size="small" custom-style="margin-left:10px;" bind:click="onDutyResBtnClick">责任回复</van-button>
-    <van-button round wx:if="{{showBtn.approveAuditBtn}}" type="info" size="small" custom-style="margin-left:10px;" bind:click="onApproveBtnClick">课长审核</van-button>
-    <van-button round wx:if="{{showBtn.examAuditBtn}}" type="info" size="small" custom-style="margin-left:10px;" bind:click="onApproveBtnClick">经理审核</van-button>
+  <view border="{{ true }}" style="background-color: #fff;width:100%;position:fixed;text-align: right;bottom:0px;border-top: 2rpx solid #eee;z-index: 999;">
+  <view class="repairDetailBtnWrap">
+    <van-button round wx:if="{{showBtn.deleteBtn}}" custom-class="repairDetailBtn" color="#DCDCDC" size="small" custom-style="color:#696969;" bind:click="onDeleteBtnClick" >作废</van-button>
+    <van-button round wx:if="{{showBtn.detailCheckBtn}}" custom-class="repairDetailBtn" type="info" size="small" bind:click="onDetailBtnClick">维修详情</van-button>
+    <van-button round wx:if="{{showBtn.arrivalCheckBtn}}" custom-class="repairDetailBtn" disabled="{{disableBtn.arrivalCheckBtn}}" type="info" size="small" bind:click="onCheckBtnClick">维修员到达</van-button>
+    <van-button round wx:if="{{showBtn.finishCheckBtn}}" custom-class="repairDetailBtn" disabled="{{disableBtn.finishCheckBtn}}"  type="info" size="small" bind:click="onFinishBtnClick">确认维修完成</van-button>
+    <van-button round wx:if="{{showBtn.changeServiceUserBtn}}" custom-class="repairDetailBtn" type="info" size="small" bind:click="onChangeServiceUserBtnClick">转派维修人</van-button>
+    <van-button round wx:if="{{showBtn.startAuditBtn}}" custom-class="repairDetailBtn" type="info" size="small" bind:click="onAuditBtnClick">发起维修验收</van-button>
+    <van-button round wx:if="{{showBtn.saveRepairInfoBtn}}" custom-class="repairDetailBtn" disabled="{{disableBtn.saveRepairInfoBtn}}"  type="info" size="small" bind:click="onAuditBtnClick">记录维修过程</van-button>
+    <van-button round wx:if="{{showBtn.stopRepairBtn}}" custom-class="repairDetailBtn" disabled="{{disableBtn.stopRepairBtn}}" type="info" size="small" bind:click="onStopBtnClick">暂停维修</van-button>
+    <van-button round wx:if="{{showBtn.startRepairBtn}}" custom-class="repairDetailBtn" disabled="{{disableBtn.startRepairBtn}}" type="info" size="small" bind:click="onStartBtnClick">开始维修</van-button>
+    <van-button round wx:if="{{showBtn.responseDutyBtn}}" custom-class="repairDetailBtn" type="info" size="small" bind:click="onDutyResBtnClick">责任回复</van-button>
+    <van-button round wx:if="{{showBtn.approveAuditBtn}}" custom-class="repairDetailBtn" type="info" size="small" bind:click="onApproveBtnClick">课长审核</van-button>
+    <van-button round wx:if="{{showBtn.examAuditBtn}}" custom-class="repairDetailBtn" type="info" size="small" bind:click="onApproveBtnClick">经理审核</van-button>
   </view>
-  </van-cell>
+  </view>
 </van-cell-group>
 
 <!-- <van-button type="info" icon="passed" form-type="submit" style="width:100%;position:fixed;bottom:0px;" bind:click="eqpRepairFormSubmit" block>提交</van-button> -->

--- a/miniprogram/eam/pages/eqpManagement/eqpRepairDocDetail.wxss
+++ b/miniprogram/eam/pages/eqpManagement/eqpRepairDocDetail.wxss
@@ -204,3 +204,13 @@
     line-height: 40rpx;
     padding-top: 4rpx;
   }
+
+  .repairDetailBtnWrap{
+    margin-right: 10px;
+    margin-bottom: 9px;
+  }
+
+  .repairDetailBtn{
+    margin-top: 7px;
+    margin-left:10px;
+  }

--- a/miniprogram/eam/pages/eqpManagement/eqpRepairDutyResponse.js
+++ b/miniprogram/eam/pages/eqpManagement/eqpRepairDutyResponse.js
@@ -1311,7 +1311,7 @@ upload: function(e) {
             newItem.pId = repairHisListInfo[i].pid;
             newItem.userNo = repairHisListInfo[i].userno;
             newItem.userName = repairHisListInfo[i].username;
-            newItem.creDate = _this.utcInit(repairHisListInfo[i].credate);
+            newItem.creDate = util.utcInit(repairHisListInfo[i].credate);
             newItem.contenct = repairHisListInfo[i].contenct;
             newItem.note = repairHisListInfo[i].note;
             _this.data.repairHisList.push(newItem);

--- a/miniprogram/eam/pages/eqpManagement/startEqpRepair.js
+++ b/miniprogram/eam/pages/eqpManagement/startEqpRepair.js
@@ -441,8 +441,8 @@ upload: function(e) {
         }
       }
 
-
-      restUrl += '/s' + '/' + 0 + '/' + 20 + '?searchInfo=' + res;
+      //restUrl += '/s' + '/' + 0 + '/' + 20 + '?searchInfo=' + res + '&deptNo=1N240';
+      restUrl += '/s' + '/' + 0 + '/' + 20 + '?searchInfo=' + res + '&deptCheckCode=' + app.globalData.defaultCompany + '_' + app.globalData.defaultDeptId;
       restUrl = encodeURI(restUrl);
       //console.log(restUrl);
       wx.showLoading({
@@ -1156,6 +1156,23 @@ onServiceUserPickerCancel: function(event){
     let day = dateTemp.getDate();
     let hour = dateTemp.getHours();
     let minute = dateTemp.getMinutes();
+
+    if(month < '10'){
+      month = "0" + month;
+    }
+  
+    if(day < '10'){
+      day = "0" + day;
+    }
+  
+    if(hour < '10'){
+      hour = "0" + hour;
+    }
+  
+    if(minute < '10'){
+      minute = "0" + minute;
+    }
+
     let dayTemp = year + "/" + month + "/" + day + "  " + hour + ":" + minute;
     return dayTemp;
   },
@@ -1266,7 +1283,7 @@ onServiceUserPickerCancel: function(event){
       return false;
     }
     console.log(this.data.serviceuser);
-    if(this.data.troubleFrom == null || this.data.formdateTS == null || this.data.serviceuser == null || this.data.troubleDetailInfo == null || this.data.uploaderList.length < 1 || this.data.repairAreaObj.repairAreaValue == '-1'){
+    if(this.data.troubleFrom == null || this.data.formdateTS == null || (this.data.serviceuser == null && !this.data.disableServiceUser) || this.data.troubleDetailInfo == null || this.data.uploaderList.length < 1 || this.data.repairAreaObj.repairAreaValue == '-1'){
       Dialog.alert({
         title: '系统消息',
         message: "请将信息填写完整",
@@ -1278,12 +1295,31 @@ onServiceUserPickerCancel: function(event){
         });
       return false;
     }
+
+    console.log(this.data.formdateTS);
+    console.log(this.data.suppleStartDateObj);
+
     if(this.data.supplementFlag){
 
       if(this.data.suppleStartDateObj == null || JSON.stringify(this.data.suppleStartDateObj) === '{}'){
         Dialog.alert({
           title: '系统消息',
           message: "请选择维修到达时间",
+          zIndex:1000,
+          }).then(() => {
+            this.setData({
+              textareaDisabled:false
+            });
+          });
+        return false;
+      }
+
+      var startDateTSTemp = (this.data.suppleStartDateObj == null || JSON.stringify(this.data.suppleStartDateObj) === '{}') ? 0 : this.data.suppleStartDateObj.dateTS;
+      var completeDateTSTemp = (this.data.suppleCompleteDateObj == null || JSON.stringify(this.data.suppleCompleteDateObj) === '{}') ? 0 : this.data.suppleCompleteDateObj.dateTS;
+      if(startDateTSTemp < this.data.formdateTS || (completeDateTSTemp < startDateTSTemp && completeDateTSTemp != 0)){
+        Dialog.alert({
+          title: '系统消息',
+          message: "请确认故障到达和完成时间是否填写正确",
           zIndex:1000,
           }).then(() => {
             this.setData({

--- a/miniprogram/eam/pages/eqpManagement/startEqpRepair.wxml
+++ b/miniprogram/eam/pages/eqpManagement/startEqpRepair.wxml
@@ -297,7 +297,7 @@
     readonly
   />
 
-  <van-cell center title="二次维修">
+  <van-cell center title="重复维修">
     <van-switch class="cellSwitchPro" size="24px" checked="{{ reRepairFlag }}" bind:change="on2ndRepairChange" />
   </van-cell>
 

--- a/miniprogram/utils/eamCommonUtils.js
+++ b/miniprogram/utils/eamCommonUtils.js
@@ -1,0 +1,95 @@
+let systemInfo;
+export function getSystemInfo() {
+  if (systemInfo) return systemInfo;
+  systemInfo = wx.getSystemInfoSync();
+  return systemInfo;
+}
+
+/**
+ *  UTC日期字符串转UTC+8时区的日期
+ * @param {string} utc_datetime UTC日期字符串
+ */
+export function utcInit(utc_datetime) {
+  if(utc_datetime == null || utc_datetime == ''){
+    return null;
+  }
+  // 转为正常的时间格式 年-月-日 时:分:秒
+  var T_pos = utc_datetime.indexOf('T');
+  var Z_pos = utc_datetime.indexOf('Z');
+  var year_month_day = utc_datetime.substr(0,T_pos);
+  var hour_minute_second = utc_datetime.substr(T_pos+1,Z_pos-T_pos-1);
+  var new_datetime = year_month_day+" "+hour_minute_second; // 2017-03-31 08:02:06
+  var new_datetimeInit = new_datetime.replace(/-/g, '/');
+
+  // 处理成为时间戳
+  timestamp = new Date(Date.parse(new_datetimeInit));
+  timestamp = timestamp.getTime();
+  timestamp = timestamp/1000;
+
+  // 增加8个小时，北京时间比utc时间多八个时区
+  var timestamp = timestamp+8*60*60;
+
+  // 时间戳转为时间
+  //var beijing_datetime = new Date(parseInt(timestamp) * 1000).toLocaleString().replace(/年|月/g, "-").replace(/日/g, " ");
+  let dateTemp = new Date(parseInt(timestamp) * 1000);
+  let year = dateTemp.getFullYear();
+  let month = dateTemp.getMonth() + 1;
+  let day = dateTemp.getDate();
+  let hour = dateTemp.getHours();
+  let minute = dateTemp.getMinutes();
+
+  if(month < '10'){
+    month = "0" + month;
+  }
+
+  if(day < '10'){
+    day = "0" + day;
+  }
+
+  if(hour < '10'){
+    hour = "0" + hour;
+  }
+
+  if(minute < '10'){
+    minute = "0" + minute;
+  }
+
+  let dayTemp = year + "/" + month + "/" + day + "  " + hour + ":" + minute;
+
+  return dayTemp;
+
+
+  //return beijing_datetime; // 2017-03-31 16:02:06
+}
+
+/**
+ *  日期字符串格式化
+ * @param {string} date 日期字符串
+ */
+export function dateFormatForFilter(date){
+  let dateTemp = new Date(date);
+  let year = dateTemp.getFullYear();
+  let month = dateTemp.getMonth() + 1;
+  let day = dateTemp.getDate();
+  let hour = dateTemp.getHours();
+  let minute = dateTemp.getMinutes();
+
+  if(month < '10'){
+    month = "0" + month;
+  }
+
+  if(day < '10'){
+    day = "0" + day;
+  }
+
+  if(hour < '10'){
+    hour = "0" + hour;
+  }
+
+  if(minute < '10'){
+    minute = "0" + minute;
+  }
+
+  let dayTemp = year + "/" + month + "/" + day + "  " + hour + ":" + minute;
+  return dayTemp;
+}


### PR DESCRIPTION
1.优化"查看部门单据"功能，调整范围限制
2.设备报修调整为只能查询并报修自己部门的设备
3.修复"查询维修单"页面个别机型无法下拉刷新的问题
4.优化低分辨率机型在"维修单详情"页面的显示效果
5.报修单详情页面新增"拨号"功能
6.设备报修功能已支持柯茂的人员使用
7.维修课长审核页面新增"是否归档"选项
8.优化"维修课长"与"维修经理"默认查询单据的状态